### PR TITLE
Export and Import Music

### DIFF
--- a/BrawlManagerLib/BrawlManagerLib.csproj
+++ b/BrawlManagerLib/BrawlManagerLib.csproj
@@ -54,6 +54,12 @@
     </Compile>
     <Compile Include="CustomSongVolume.cs" />
     <Compile Include="CustomSSS.cs" />
+    <Compile Include="ProgressDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ProgressDialog.Designer.cs">
+      <DependentUpon>ProgressDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/BrawlManagerLib/BrawlManagerLib.csproj
+++ b/BrawlManagerLib/BrawlManagerLib.csproj
@@ -112,6 +112,9 @@
     <EmbeddedResource Include="NameDialog.resx">
       <DependentUpon>NameDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="ProgressDialog.resx">
+      <DependentUpon>ProgressDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/BrawlManagerLib/FileOperations.cs
+++ b/BrawlManagerLib/FileOperations.cs
@@ -11,8 +11,8 @@ namespace BrawlManagerLib {
 	///  A modification of David Amenta's RecycleBin code
 	/// </summary>
 	public static class FileOperations {
-		public static bool Copy(string path1, string path2, bool deleteFirst = false) {
-			if (File.Exists(path2)) {
+		public static bool Copy(string path1, string path2, bool deleteFirst = false, bool confirmOverwrite = true) {
+			if (File.Exists(path2) && confirmOverwrite) {
 				using (CopyDialog dialog = new CopyDialog(path2, path1) { Text = "Copy" }) {
 					DialogResult r = dialog.ShowDialog();
 					if (r != DialogResult.Yes) {
@@ -266,6 +266,13 @@ namespace BrawlManagerLib {
 		/// <param name="path">Location of directory or file to recycle</param>
 		public static bool Delete(string path) {
 			return Delete(path, FileOperationFlags.FOF_WANTNUKEWARNING);
+		}
+
+		public static string SantizeFilename(string filename) {
+			string invalidChars = System.Text.RegularExpressions.Regex.Escape(new string(System.IO.Path.GetInvalidFileNameChars()));
+			string invalidRegStr = string.Format(@"([{0}]*\.+$)|([{0}]+)", invalidChars);
+
+			return System.Text.RegularExpressions.Regex.Replace(filename, invalidRegStr, "_");
 		}
 	}
 }

--- a/BrawlManagerLib/ProgressDialog.Designer.cs
+++ b/BrawlManagerLib/ProgressDialog.Designer.cs
@@ -25,31 +25,73 @@
 		private void InitializeComponent() {
 			this.ProgressBar = new System.Windows.Forms.ProgressBar();
 			this.ProgressLabel = new System.Windows.Forms.Label();
+			this.label1 = new System.Windows.Forms.Label();
+			this.logTextBox = new System.Windows.Forms.RichTextBox();
+			this.okButton = new System.Windows.Forms.Button();
 			this.SuspendLayout();
 			// 
 			// ProgressBar
 			// 
-			this.ProgressBar.Location = new System.Drawing.Point(12, 45);
+			this.ProgressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.ProgressBar.Location = new System.Drawing.Point(12, 25);
 			this.ProgressBar.Name = "ProgressBar";
-			this.ProgressBar.Size = new System.Drawing.Size(305, 23);
+			this.ProgressBar.Size = new System.Drawing.Size(407, 23);
 			this.ProgressBar.TabIndex = 1;
 			// 
 			// ProgressLabel
 			// 
 			this.ProgressLabel.AutoSize = true;
-			this.ProgressLabel.Location = new System.Drawing.Point(12, 20);
+			this.ProgressLabel.Location = new System.Drawing.Point(12, 9);
 			this.ProgressLabel.Name = "ProgressLabel";
 			this.ProgressLabel.Size = new System.Drawing.Size(57, 13);
 			this.ProgressLabel.TabIndex = 2;
 			this.ProgressLabel.Text = "Progress...";
 			this.ProgressLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(12, 60);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(72, 13);
+			this.label1.TabIndex = 4;
+			this.label1.Text = "Progress Log:";
+			this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// logTextBox
+			// 
+			this.logTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.logTextBox.Location = new System.Drawing.Point(15, 76);
+			this.logTextBox.Name = "logTextBox";
+			this.logTextBox.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+			this.logTextBox.Size = new System.Drawing.Size(404, 150);
+			this.logTextBox.TabIndex = 5;
+			this.logTextBox.Text = "";
+			// 
+			// okButton
+			// 
+			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.okButton.Enabled = false;
+			this.okButton.Location = new System.Drawing.Point(344, 232);
+			this.okButton.Name = "okButton";
+			this.okButton.Size = new System.Drawing.Size(75, 23);
+			this.okButton.TabIndex = 6;
+			this.okButton.Text = "Ok";
+			this.okButton.UseVisualStyleBackColor = true;
+			this.okButton.Click += new System.EventHandler(this.okButton_Click);
+			// 
 			// ProgressDialog
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(329, 80);
+			this.ClientSize = new System.Drawing.Size(431, 267);
 			this.ControlBox = false;
+			this.Controls.Add(this.okButton);
+			this.Controls.Add(this.logTextBox);
+			this.Controls.Add(this.label1);
 			this.Controls.Add(this.ProgressLabel);
 			this.Controls.Add(this.ProgressBar);
 			this.Name = "ProgressDialog";
@@ -63,5 +105,8 @@
 
 		private System.Windows.Forms.ProgressBar ProgressBar;
 		private System.Windows.Forms.Label ProgressLabel;
+		private System.Windows.Forms.Label label1;
+		private System.Windows.Forms.RichTextBox logTextBox;
+		private System.Windows.Forms.Button okButton;
 	}
 }

--- a/BrawlManagerLib/ProgressDialog.Designer.cs
+++ b/BrawlManagerLib/ProgressDialog.Designer.cs
@@ -1,0 +1,67 @@
+﻿namespace BrawlManagerLib {
+	partial class ProgressDialog {
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing) {
+			if (disposing && (components != null)) {
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent() {
+			this.ProgressBar = new System.Windows.Forms.ProgressBar();
+			this.ProgressLabel = new System.Windows.Forms.Label();
+			this.SuspendLayout();
+			// 
+			// ProgressBar
+			// 
+			this.ProgressBar.Location = new System.Drawing.Point(12, 45);
+			this.ProgressBar.Name = "ProgressBar";
+			this.ProgressBar.Size = new System.Drawing.Size(305, 23);
+			this.ProgressBar.TabIndex = 1;
+			// 
+			// ProgressLabel
+			// 
+			this.ProgressLabel.AutoSize = true;
+			this.ProgressLabel.Location = new System.Drawing.Point(12, 20);
+			this.ProgressLabel.Name = "ProgressLabel";
+			this.ProgressLabel.Size = new System.Drawing.Size(57, 13);
+			this.ProgressLabel.TabIndex = 2;
+			this.ProgressLabel.Text = "Progress...";
+			this.ProgressLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// ProgressDialog
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(329, 80);
+			this.ControlBox = false;
+			this.Controls.Add(this.ProgressLabel);
+			this.Controls.Add(this.ProgressBar);
+			this.Name = "ProgressDialog";
+			this.Text = "Progress";
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.ProgressBar ProgressBar;
+		private System.Windows.Forms.Label ProgressLabel;
+	}
+}

--- a/BrawlManagerLib/ProgressDialog.cs
+++ b/BrawlManagerLib/ProgressDialog.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace BrawlManagerLib {
+	public partial class ProgressDialog : Form {
+		public ProgressDialog() {
+			InitializeComponent();
+		}
+
+		public string ProgressTitle {
+			get { return Text; }
+			set { Text = value; }
+		}
+
+		public string InProgressLabel {
+			get { return ProgressLabel.Text; }
+			set { ProgressLabel.Text = value; }
+		}
+
+		public int ProgressCompletionAt {
+			get { return ProgressBar.Maximum; }
+			set { ProgressBar.Maximum = value; }
+		}
+
+		public int Progress {
+			get { return ProgressBar.Value; }
+			set { ProgressBar.Value = value; }
+		}
+	}
+}

--- a/BrawlManagerLib/ProgressDialog.cs
+++ b/BrawlManagerLib/ProgressDialog.cs
@@ -25,12 +25,38 @@ namespace BrawlManagerLib {
 
 		public int ProgressCompletionAt {
 			get { return ProgressBar.Maximum; }
-			set { ProgressBar.Maximum = value; }
+			set { 
+				ProgressBar.Maximum = value; 
+				CheckOkButtonEnabled();
+			}
 		}
 
 		public int Progress {
 			get { return ProgressBar.Value; }
-			set { ProgressBar.Value = value; }
+			set { 
+				ProgressBar.Value = value;
+				CheckOkButtonEnabled();
+			}
 		}
+
+		public void AppendLogLine(string value) {
+			if (logTextBox.Text.Length == 0)
+				logTextBox.Text = value;
+			else
+				logTextBox.AppendText("\n" + value);
+		}
+
+		public void ClearLog() {
+			logTextBox.Clear();
+		}
+
+		private void CheckOkButtonEnabled() {
+			okButton.Enabled = Progress >= ProgressCompletionAt;
+		}
+
+		private void okButton_Click(object sender, EventArgs e) {
+			Close();
+		}
+
 	}
 }

--- a/BrawlManagerLib/ProgressDialog.resx
+++ b/BrawlManagerLib/ProgressDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SongManager/BrawlSongManager.txt
+++ b/SongManager/BrawlSongManager.txt
@@ -47,6 +47,42 @@ running BrawlSongManager.exe from the root of your SD card.)
 
 ----------------------------------------
 
+Importing and Exporting Song Files
+
+Both importing and exporting first require changing directory to an appropriate
+"SD  card". Then under the Tools menu there are options to import or export 
+song files.
+
+Export will output songs on the current SD card to the folder you choose. In 
+the directory you choose it will create a number of directories for each stage
+and inside each stage directory it will place the songs for that stage. Songs
+that do not have a custom file on the SD card will have place-holders exported
+as empty files that users can then replace. The empty files will be ignored 
+when importing.
+
+After songs have been exported, users can edit song volumes or titles, or even
+replace songs. The only requirement is that the file name format conforms to
+the format specified below. The 'game-file-name' should remain unchanged, and 
+there should only be one of each 'game-file-name'.
+
+Import will scan (recursively) in the directory you choose for *.brstm files 
+that match the file name format specified below. Any matching files will be 
+copied onto the current SD card with the appropriate "game-file-name" as the
+file name. mu_menumain.pac and info.pac will updated, and if found on the SD
+card, training_info.pac and the GCT codes will also be updated. Note that the
+stage directories are ignored when importing (they are just an aid for users). 
+
+The file name format for the files exported / imported is:
+    <game-file-name>.<volume>.<song-title>.brstm 
+Some examples of this format are:
+    W05.35.Yoshi's Island (Melee).brstm
+    Y05.0.Boss Battle Song 1.brstm
+    
+When imported, a volume of 0 will reset the volume for that song to default, 
+while volumes above 127 (the max) will be set to 127.
+
+----------------------------------------
+
 Changes in 3.4:
 	* Control added to edit Custom Song Volume settings for each song
 	* You can now use "Options>Only show songs with CSV code" to see which songs have custom volumes defined (note: does not automatically refresh)

--- a/SongManager/MainForm.Designer.cs
+++ b/SongManager/MainForm.Designer.cs
@@ -39,6 +39,7 @@
 			this.changeDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.openFallbackDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.saveInfopacToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.saveGCTCodesetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.loadNamesFromInfopacToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -48,12 +49,13 @@
 			this.onlyShowSongsWithCSVCodeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.updateMumenumainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.exportMusicSongsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.importMusicSongsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.defaultSongsListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.statusToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.splitContainerTop = new System.Windows.Forms.SplitContainer();
-			this.saveGCTCodesetToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
 			this.splitContainer1.Panel1.SuspendLayout();
 			this.splitContainer1.Panel2.SuspendLayout();
@@ -208,6 +210,13 @@
 			this.saveInfopacToolStripMenuItem.Text = "Save info.pac";
 			this.saveInfopacToolStripMenuItem.Click += new System.EventHandler(this.saveInfopacToolStripMenuItem_Click);
 			// 
+			// saveGCTCodesetToolStripMenuItem
+			// 
+			this.saveGCTCodesetToolStripMenuItem.Name = "saveGCTCodesetToolStripMenuItem";
+			this.saveGCTCodesetToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
+			this.saveGCTCodesetToolStripMenuItem.Text = "Save GCT codeset";
+			this.saveGCTCodesetToolStripMenuItem.Click += new System.EventHandler(this.saveGCTCodesetToolStripMenuItem_Click);
+			// 
 			// exitToolStripMenuItem
 			// 
 			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
@@ -267,7 +276,9 @@
 			// toolsToolStripMenuItem
 			// 
 			this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.updateMumenumainToolStripMenuItem});
+            this.updateMumenumainToolStripMenuItem,
+            this.exportMusicSongsToolStripMenuItem,
+            this.importMusicSongsToolStripMenuItem});
 			this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
 			this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
 			this.toolsToolStripMenuItem.Text = "Tools";
@@ -278,6 +289,20 @@
 			this.updateMumenumainToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
 			this.updateMumenumainToolStripMenuItem.Text = "Update mu_menumain";
 			this.updateMumenumainToolStripMenuItem.Click += new System.EventHandler(this.updateMumenumainToolStripMenuItem_Click);
+			// 
+			// exportMusicSongsToolStripMenuItem
+			// 
+			this.exportMusicSongsToolStripMenuItem.Name = "exportMusicSongsToolStripMenuItem";
+			this.exportMusicSongsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+			this.exportMusicSongsToolStripMenuItem.Text = "Export songs...";
+			this.exportMusicSongsToolStripMenuItem.Click += new System.EventHandler(this.exportMusicSongsToolStripMenuItem_Click);
+			// 
+			// importMusicSongsToolStripMenuItem
+			// 
+			this.importMusicSongsToolStripMenuItem.Name = "importMusicSongsToolStripMenuItem";
+			this.importMusicSongsToolStripMenuItem.Size = new System.Drawing.Size(196, 22);
+			this.importMusicSongsToolStripMenuItem.Text = "Import songs...";
+			this.importMusicSongsToolStripMenuItem.Click += new System.EventHandler(this.importMusicSongsToolStripMenuItem_Click);
 			// 
 			// helpToolStripMenuItem
 			// 
@@ -324,13 +349,6 @@
 			this.splitContainerTop.Size = new System.Drawing.Size(592, 290);
 			this.splitContainerTop.SplitterDistance = 197;
 			this.splitContainerTop.TabIndex = 0;
-			// 
-			// saveGCTCodesetToolStripMenuItem
-			// 
-			this.saveGCTCodesetToolStripMenuItem.Name = "saveGCTCodesetToolStripMenuItem";
-			this.saveGCTCodesetToolStripMenuItem.Size = new System.Drawing.Size(197, 22);
-			this.saveGCTCodesetToolStripMenuItem.Text = "Save GCT codeset";
-			this.saveGCTCodesetToolStripMenuItem.Click += new System.EventHandler(this.saveGCTCodesetToolStripMenuItem_Click);
 			// 
 			// MainForm
 			// 
@@ -391,6 +409,8 @@
 		private System.Windows.Forms.ToolStripMenuItem onlyShowSongsWithCSVCodeToolStripMenuItem;
 		private CustomSongVolumeEditor customSongVolumeEditor1;
 		private System.Windows.Forms.ToolStripMenuItem saveGCTCodesetToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem exportMusicSongsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem importMusicSongsToolStripMenuItem;
 
 
 

--- a/SongManager/MainForm.cs
+++ b/SongManager/MainForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Windows.Forms;
 using BrawlLib.SSBB.ResourceNodes;
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using BrawlManagerLib;
 using System.Linq;
 using System.Drawing;
+using BrawlSongManager.SongExport;
 
 namespace BrawlSongManager {
 	public partial class MainForm : Form {
@@ -445,6 +446,44 @@ namespace BrawlSongManager {
 
 		private void closed(object sender, FormClosedEventArgs e) {
 			TempFiles.DeleteAll();
+		}
+
+		private void CloseCurrentResources() {
+			songPanel1.Close();
+			listBox1.SelectedIndex = -1;
+		}
+
+		private void exportMusicSongsToolStripMenuItem_Click(object sender, EventArgs eva) {
+			CloseCurrentResources();
+			FolderBrowserDialog fbd = new FolderBrowserDialog();
+			fbd.Description = "Select folder to export to:";
+			fbd.SelectedPath = CurrentDirectory;
+			if (fbd.ShowDialog() == DialogResult.OK) {
+				try {
+					SongExporter exporter = new SongExporter();
+					//exporter.ExportStageDirs = groupSongsByStageToolStripMenuItem.Checked;
+					exporter.ExportStageDirs = true;
+					exporter.Export(fbd.SelectedPath);
+				} catch (Exception exc) {
+					MessageBox.Show("Error exporting: " + exc);
+				}
+			}
+		}
+
+		private void importMusicSongsToolStripMenuItem_Click(object sender, EventArgs eva) {
+			CloseCurrentResources();
+			FolderBrowserDialog fbd = new FolderBrowserDialog();
+			fbd.Description = "Select folder to import from:";
+			fbd.SelectedPath = CurrentDirectory;
+			if (fbd.ShowDialog() == DialogResult.OK) {
+				try {
+					SongImporter importer = new SongImporter();
+					importer.Import(fbd.SelectedPath);
+				} catch (Exception exc) {
+					MessageBox.Show("Error importing: " + exc);
+				}
+			}
+			changeDirectory(CurrentDirectory);
 		}
 	}
 }

--- a/SongManager/MainForm.resx
+++ b/SongManager/MainForm.resx
@@ -124,17 +124,17 @@
   <data name="customSongVolumeEditor1.VolumeIcon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJcSURBVDhPtYtdSJNhGIZfC4VpxEBQy4jKoJPIgxoFHQQd
-        dBBplGGNJHYQueWGBztJ2rS0HysGFWXUNFnbPrdZyzZ1m8795L7NzaWu5nDmSpgmMbG1aX9Ed3N+J4KE
-        HnTBxfs+z3Pf5L8iFouzme/aEYlEWQaDzaHRdN1kVmtDLjdLA74rMBuvLzTK3BxmvToaGlw7Op4rP/9M
-        sjA3XQy1ymRmTquDolxU0C/AxwgLk2MsDDpvQa4YKWfO/6ZV6T084FZ+G6K3g8cTQlpzHNGRYlh7et7V
-        1tpzmNjKSCSSDItliE7MlOL96AacLBPgYuVRxEPrMfW2Hhb75GUmujK6lwHBeFCJP/FsTAQ2Y/+BI6g4
-        zcGvcBZi9CZ4HIZPd5o/bGXiy6mr0+Xbnd5oLHwIiLMwbGKDzS5E2bEifPetQ7KPIGLlwmILtTCV5Wj1
-        /nvjg1Ik3xD8DhJ4VQQkg4Xy0l1I9BIkOgmiVCb6Ou4vPNYFDzK1JWSPnByDnkpG7blIeAi+9hNMdRHc
-        rsqEvjEHcQNBrD2lmmBUtRe6F902prrEM02vOWg/gyS9VP6RckJLsG/3Rkgu7MT8K4LZ1DyrIZhuJXDq
-        LqG5baAiXZYrzFybqQkz9kIk6ALMOQow/zoPUUMuzpcVoUnKQbw7HzHjlrRfOvMQ1u5Be5siXHPXmkdU
-        al2r32OE2/QALtMTeK1PMdxPIeTVIjKkwZiPQoDWwu9Qw9PTks64TQ9BO8y4ek12igiFwm0CQfWJs3xJ
-        yaL8qrqU9SX86htpq9Jvak7tzjGZRXmVlaVcLpf9F3dpaALjzhlWAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsAAAA7AAWrWiQkAAAJWSURBVDhPtYtdSJNhGIbfEqv1h7Awa0WEQSeRYEmeedbB
+        ikUNTKMDGWOy2sBO0sRtJYLWQSSVqaXm3L42/2LT/aibm85vYzp/JttQcyhM82Bi65vQD9HdnF8HQoUe
+        dMHF+z7Pc9/kv6JUKvey352jUqlSDAa7naJ6q9jVzmhoMJf7Rx/CbKxiKqtd2ex6e5SWOk6971B//Bbn
+        YG05C21qs4k9bQ+NxtUW8EmxEOZgcYaDsaHHeNU0IWTP/+Z1iyfPPdIan6BPo6hIBsWDa4hMZWGgr2+q
+        pES/j439Hat1fJhZEeBD8CBuCKW4U8xHLJSCpelKWOwLZWzsz+i6JiVzgTb8jO3HvP84LuVexu2bOfg+
+        uwdR+hhohyGiqp3jsfGtyOVNR+wOz2J0Ng+IcTBpSUNaGg/Cq5n4MrobcTtB2FYIqz3YyFa28q5z7Onc
+        mALxcYIfAQKvhoDs4iBfcBbMAAHTSxChUmHrfsY8107nsrVNqmsHsw1d2ljEwQXjIfjsIlgyETy5m4ru
+        mgOIGQmiHQm1BEHNBeg7TQNsdZNWqt8UcBQgTm+Wvyac1xNcPHcYFZIzWDcQrCbmVR3BcgvBUHsZ6jXu
+        wmS5vtmUP2ipw4qDB4bOwJozA+vD6YgYuRALM1GnyEHMfBTRnhNJP/WmY1Z/Hu3U29A9lZFL1BrdG5+n
+        B27LC4xYGuG1NWPSRSHk1SM8ocPMKAU/rYfPqYWnvymZcVtegnZaUaGquU4kEsnJ4mK5oEB0n7+hSFqe
+        UMEXyR4llSbfxJzY/c5seEssviKTyQ79AqkQZDQJVaF7AAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/SongManager/SongExport/SongEditor.cs
+++ b/SongManager/SongExport/SongEditor.cs
@@ -1,0 +1,193 @@
+﻿using BrawlLib.SSBB.ResourceNodes;
+using BrawlManagerLib;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace BrawlSongManager.SongExport {
+	class SongEditor {
+		static readonly string[] GCT_PATHS = {
+			"RSBE01.gct",
+			"/data/gecko/codes/RSBE01.gct",
+			"/codes/RSBE01.gct",
+			"../../../../codes/RSBE01.gct",
+		};
+		static readonly string[] MUM_PATHS = { 
+			"../../menu2/mu_menumain.pac",
+			"../../menu2/mu_menumain_en.pac",
+			"../../../pfmenu2/mu_menumain.pac",
+			"../../../pfmenu2/mu_menumain_en.pac"
+		};
+		static readonly string[] INFO_PATHS = {
+			"..\\..\\info2\\info.pac",
+			"..\\..\\info2\\info_en.pac",
+			"..\\info.pac"
+		};
+		static readonly string[] TRNG_PATHS = {
+			"..\\..\\info2\\info_training.pac",
+			"..\\..\\info2\\info_training_en.pac",
+			"..\\info_training.pac"
+		};
+
+		// MU_MenuMain Details
+		private string mumPath;
+		private MSBinNode mumMsbn;
+
+		// INFO Details
+		private string infoPath;
+		private MSBinNode infoMsbn;
+
+		// TRNG Details
+		private string trngPath;
+		private MSBinNode trngMsbn;
+
+		// Volume Details
+		private string gctPath;
+		private CustomSongVolume gctCsv;
+
+		public SongEditor() {
+
+		}
+
+		public void PrepareResources() {
+			PrepareMUM();
+			PrepareINFO();
+			PrepareTRNG();
+			PrepareGCT();
+		}
+
+		public Song ReadSong(string filename) {
+			Song mapSong = GetDefaultSong(filename);
+			if (mapSong == null) {
+				return null;
+			}
+			return UpdateSongFromFileData(mapSong);
+		}
+
+		public Song GetDefaultSong(string filename) {
+			return (from s in SongIDMap.Songs
+					where s.Filename == filename
+					select s).FirstOrDefault();
+		}
+
+		public void WriteSong(Song song) {
+			if (song.InfoPacIndex.HasValue) {
+				mumMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
+				mumMsbn.SignalPropertyChange();
+				infoMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
+				infoMsbn.SignalPropertyChange();
+				trngMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
+				trngMsbn.SignalPropertyChange();
+			}
+			if (song.DefaultVolume.HasValue) {
+				gctCsv.Settings[song.ID] = song.DefaultVolume.Value;
+			}
+		}
+
+		public void SaveResources() {
+			SaveMUM();
+			SaveINFO();
+			SaveTRNG();
+			SaveGCT();
+		}
+
+		private Song UpdateSongFromFileData(Song song) {
+			string title = song.DefaultName;
+			if (song.InfoPacIndex.HasValue) {
+				title = mumMsbn._strings[song.InfoPacIndex.Value];
+			}
+
+			byte? volume = song.DefaultVolume;
+			if (gctCsv.Settings.ContainsKey(song.ID)) {
+				volume = gctCsv.Settings[song.ID];
+			}
+
+			return new Song(title, song.Filename, song.ID, volume, song.InfoPacIndex);
+		}
+
+		private void PrepareMUM() {
+			mumPath = FindFile(MUM_PATHS);
+			mumMsbn = LoadPacMsbn(mumPath, "MiscData[7]");
+		}
+
+		private void SaveMUM() {
+			mumMsbn.Rebuild();
+			SavePacMsbn(mumMsbn, mumPath, "MiscData[7]");
+		}
+
+		private void PrepareINFO() {
+			infoPath = FindFile(INFO_PATHS);
+			infoMsbn = LoadPacMsbn(infoPath, "MiscData[140]");
+		}
+
+		private void SaveINFO() {
+			infoMsbn.Rebuild();
+			SavePacMsbn(infoMsbn, infoPath, "MiscData[140]");
+		}
+
+		private void PrepareTRNG() {
+			trngPath = FindFile(TRNG_PATHS);
+			trngMsbn = LoadPacMsbn(trngPath, "MiscData[140]");
+		}
+
+		private void SaveTRNG() {
+			trngMsbn.Rebuild();
+			SavePacMsbn(trngMsbn, trngPath, "MiscData[140]");
+		}
+
+		private void PrepareGCT() {
+			gctPath = FindFile(GCT_PATHS);
+			gctCsv = new CustomSongVolume(File.ReadAllBytes(gctPath));
+			int ct = gctCsv.Settings.Count;
+			Console.WriteLine("Loaded Custom Song Volume (" + ct + " settings)");
+		}
+
+		private void SaveGCT() {
+			File.WriteAllBytes(gctPath, gctCsv.ExportGCT());
+		}
+
+		private MSBinNode LoadPacMsbn(string path, string childNodeName) {
+			using (ResourceNode node = NodeFactory.FromFile(null, path)) {
+				var childNode = node.FindChild(childNodeName, true) as MSBinNode;
+				if (childNode == null) {
+					throw new Exception("Node '" + childNodeName + "' not found in '" + path + "'");
+				}
+				return childNode;
+			}
+		}
+
+		private void SavePacMsbn(MSBinNode msbn, string pacPath, string childNodeName) {
+			string tmpPac = Path.GetTempFileName();
+			string tmpMsbn = Path.GetTempFileName();
+			msbn.Export(tmpMsbn);
+			File.Copy(pacPath, tmpPac, true);
+
+			using (ResourceNode tmpPacNode = NodeFactory.FromFile(null, tmpPac)) {
+				MSBinNode tmpPacChildNode = tmpPacNode.FindChild(childNodeName, true) as MSBinNode;
+				if (tmpPacChildNode == null) {
+					throw new Exception("Error saving '" + pacPath
+						+ "': The file does not appear to have a '" + childNodeName + "'");
+				} else {
+					tmpPacChildNode.Replace(tmpMsbn);
+					tmpPacNode.Merge();
+					tmpPacNode.Export(pacPath);
+				}
+			}
+
+			File.Delete(tmpPac);
+			File.Delete(tmpMsbn);
+		}
+
+		private string FindFile(string[] paths) {
+			foreach (string path in paths) {
+				if (File.Exists(path)) {
+					return path;
+				}
+			}
+			throw new FileNotFoundException("Could not find any file in: ['"
+				+ string.Join("','", paths) + "']");
+		}
+	}
+}

--- a/SongManager/SongExport/SongEditor.cs
+++ b/SongManager/SongExport/SongEditor.cs
@@ -1,4 +1,4 @@
-﻿using BrawlLib.SSBB.ResourceNodes;
+using BrawlLib.SSBB.ResourceNodes;
 using BrawlManagerLib;
 using System;
 using System.Collections.Generic;
@@ -51,7 +51,7 @@ namespace BrawlSongManager.SongExport {
 
 		}
 
-		public void PrepareResources() {
+		public void PrepareAllResources() {
 			PrepareMUM();
 			PrepareINFO();
 			PrepareTRNG();
@@ -74,23 +74,41 @@ namespace BrawlSongManager.SongExport {
 
 		public void WriteSong(Song song) {
 			if (song.InfoPacIndex.HasValue) {
-				mumMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
-				mumMsbn.SignalPropertyChange();
-				infoMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
-				infoMsbn.SignalPropertyChange();
-				trngMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
-				trngMsbn.SignalPropertyChange();
+				if (mumMsbn != null) {
+					mumMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
+					mumMsbn.SignalPropertyChange();
+				}
+				if (infoMsbn != null) {
+					infoMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
+					infoMsbn.SignalPropertyChange();
+				}
+				if (trngMsbn != null) {
+					trngMsbn._strings[song.InfoPacIndex.Value] = song.DefaultName;
+					trngMsbn.SignalPropertyChange();
+				}
 			}
-			if (song.DefaultVolume.HasValue) {
-				gctCsv.Settings[song.ID] = song.DefaultVolume.Value;
+			if (gctCsv != null) {
+				if (song.DefaultVolume.HasValue) {
+					gctCsv.Settings[song.ID] = song.DefaultVolume.Value;
+				} else if (gctCsv.Settings.ContainsKey(song.ID)) {
+					gctCsv.Settings.Remove(song.ID);
+				}
 			}
 		}
 
 		public void SaveResources() {
-			SaveMUM();
-			SaveINFO();
-			SaveTRNG();
-			SaveGCT();
+			if (mumMsbn != null && mumPath != null) {
+				SaveMUM();
+			}
+			if (infoMsbn != null && infoPath != null) {
+				SaveINFO();
+			}
+			if (trngMsbn != null && trngPath != null) {
+				SaveTRNG();
+			}
+			if (gctCsv != null && gctPath != null) {
+				SaveGCT();
+			}
 		}
 
 		private Song UpdateSongFromFileData(Song song) {
@@ -100,51 +118,49 @@ namespace BrawlSongManager.SongExport {
 			}
 
 			byte? volume = song.DefaultVolume;
-			if (gctCsv.Settings.ContainsKey(song.ID)) {
+			if (gctCsv != null && gctCsv.Settings.ContainsKey(song.ID)) {
 				volume = gctCsv.Settings[song.ID];
 			}
 
 			return new Song(title, song.Filename, song.ID, volume, song.InfoPacIndex);
 		}
 
-		private void PrepareMUM() {
+		public void PrepareMUM() {
 			mumPath = FindFile(MUM_PATHS);
 			mumMsbn = LoadPacMsbn(mumPath, "MiscData[7]");
 		}
 
-		private void SaveMUM() {
+		public void SaveMUM() {
 			mumMsbn.Rebuild();
 			SavePacMsbn(mumMsbn, mumPath, "MiscData[7]");
 		}
 
-		private void PrepareINFO() {
+		public void PrepareINFO() {
 			infoPath = FindFile(INFO_PATHS);
 			infoMsbn = LoadPacMsbn(infoPath, "MiscData[140]");
 		}
 
-		private void SaveINFO() {
+		public void SaveINFO() {
 			infoMsbn.Rebuild();
 			SavePacMsbn(infoMsbn, infoPath, "MiscData[140]");
 		}
 
-		private void PrepareTRNG() {
+		public void PrepareTRNG() {
 			trngPath = FindFile(TRNG_PATHS);
 			trngMsbn = LoadPacMsbn(trngPath, "MiscData[140]");
 		}
 
-		private void SaveTRNG() {
+		public void SaveTRNG() {
 			trngMsbn.Rebuild();
 			SavePacMsbn(trngMsbn, trngPath, "MiscData[140]");
 		}
 
-		private void PrepareGCT() {
+		public void PrepareGCT() {
 			gctPath = FindFile(GCT_PATHS);
 			gctCsv = new CustomSongVolume(File.ReadAllBytes(gctPath));
-			int ct = gctCsv.Settings.Count;
-			Console.WriteLine("Loaded Custom Song Volume (" + ct + " settings)");
 		}
 
-		private void SaveGCT() {
+		public void SaveGCT() {
 			File.WriteAllBytes(gctPath, gctCsv.ExportGCT());
 		}
 
@@ -187,7 +203,7 @@ namespace BrawlSongManager.SongExport {
 				}
 			}
 			throw new FileNotFoundException("Could not find any file in: ['"
-				+ string.Join("','", paths) + "']");
+				+ string.Join("', '", paths) + "']");
 		}
 	}
 }

--- a/SongManager/SongExport/SongExporter.cs
+++ b/SongManager/SongExport/SongExporter.cs
@@ -1,0 +1,135 @@
+using BrawlLib.SSBB.ResourceNodes;
+using BrawlManagerLib;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace BrawlSongManager.SongExport {
+	
+	/// <summary>
+	/// Contains logic for exporting music song files to an easily editable 
+	/// directory structure.
+	/// </summary> 
+	public class SongExporter {
+
+		public bool ExportStageDirs { get; set; }
+
+		private ProgressDialog prog;
+		private SongEditor songEditor;
+
+		public SongExporter() {
+			prog = new ProgressDialog();
+			songEditor = new SongEditor();
+		}
+
+		public void Export(string musicExportDir) {
+			Console.WriteLine("Exporting music from: " + musicExportDir);
+			prog.ClearLog();
+			songEditor.PrepareResources();
+
+			var confirmResult = MessageBox.Show(
+				"About to export all songs in current directory to '" 
+				+ musicExportDir + "'. Existing *.brstm files may be overwritten."
+				+ "\nDo you want to continue?", 
+				"Confirm Overwrite", MessageBoxButtons.OKCancel);
+			if (confirmResult != DialogResult.OK) {
+				return;
+			}
+
+			var exportDir = new DirectoryInfo(musicExportDir);
+
+			prog.ProgressTitle = "Exporting songs...";
+			prog.InProgressLabel = "Exporting songs...";
+			prog.ProgressCompletionAt = 100;
+
+			var bgw = SetupBackgroundExport(exportDir, prog);
+			bgw.RunWorkerAsync();
+
+			prog.ShowDialog();
+		}
+
+		private BackgroundWorker SetupBackgroundExport(DirectoryInfo exportDir, ProgressDialog prog) {
+			BackgroundWorker bgw = new BackgroundWorker();
+			bgw.DoWork += (object sender, DoWorkEventArgs e) => {
+				ExportSongs(exportDir, sender as BackgroundWorker);
+			};
+			bgw.WorkerReportsProgress = true;
+			bgw.ProgressChanged += (object sender, ProgressChangedEventArgs e) => {
+				prog.Progress = e.ProgressPercentage;
+				if (e.UserState != null) {
+					prog.InProgressLabel = (string)e.UserState;
+				}
+			};
+			bgw.RunWorkerCompleted += (object sender, RunWorkerCompletedEventArgs e) => {
+				prog.Progress = 100;
+				Log("");
+				if (e.Error != null) {
+					Log("Error exporting songs." + e.Error.Message);
+				} else {
+					Log("Completed export!");
+				}
+			};
+			return bgw;
+		}
+
+		private void ExportSongs(DirectoryInfo exportDir, BackgroundWorker bgw) {
+			object[] stageSongs = SongsByStage.FromCurrentDir;
+
+			HashSet<string> filenamesAdded = new HashSet<string>();
+			string currentDir = exportDir.FullName;
+			for (int i = 0; i < stageSongs.Length; i++) {
+				bgw.ReportProgress(i * 100 / stageSongs.Length);
+				object curObj = stageSongs[i];
+				if (curObj is string) {
+					string cur = (string)curObj;
+					bgw.ReportProgress(i * 100 / stageSongs.Length, "Exporting songs for stage: " + cur);
+					cur = FileOperations.SantizeFilename(cur);
+					if (ExportStageDirs) {
+						currentDir = exportDir.CreateSubdirectory(cur).FullName;
+					}
+				} else if (curObj is SongInfo) {
+					SongInfo cur = (SongInfo)curObj;
+					ExportSong(currentDir, cur);
+					filenamesAdded.Add(cur.File.Name);
+				}
+			}
+		}
+
+		private void ExportSong(string currentDir, SongInfo cur) {
+			string srcName = Path.GetFileNameWithoutExtension(cur.File.Name);
+			Song song = songEditor.ReadSong(srcName);
+			if (song == null) {
+				Log("Skipped unknown song: " + cur.File.FullName);
+				return;
+			}
+
+			string vol = "0";
+			if (song.DefaultVolume.HasValue) {
+				vol = song.DefaultVolume.Value.ToString();
+			}
+			string title = FileOperations.SantizeFilename(song.DefaultName);
+			string destFilename = srcName + "." + vol + "." + title + cur.File.Extension;
+			string dest = Path.Combine(currentDir, destFilename);
+
+			if (cur.File.Exists) {
+				File.Copy(cur.File.FullName, dest, true);
+			} else {
+				// Create an empty placeholder file.
+				File.Create(dest).Dispose();
+			}
+		}
+
+		private void Log(string message) {
+			if (prog.InvokeRequired) {
+				prog.BeginInvoke((Action)(() => { prog.AppendLogLine(message); }));
+			} else {
+				prog.AppendLogLine(message);
+			}
+		}
+	}
+}

--- a/SongManager/SongExport/SongExporter.cs
+++ b/SongManager/SongExport/SongExporter.cs
@@ -10,10 +10,10 @@ using System.Threading;
 using System.Windows.Forms;
 
 namespace BrawlSongManager.SongExport {
-	
+
 	/// <summary>
-	/// Contains logic for exporting music song files to an easily editable 
-	/// directory structure.
+	/// Contains logic for user to export music song files with a format like
+	/// {filename}.{volume}.{title}.brstm e.g. A01.80.Jungle Japes.brstm
 	/// </summary> 
 	public class SongExporter {
 
@@ -30,7 +30,6 @@ namespace BrawlSongManager.SongExport {
 		public void Export(string musicExportDir) {
 			Console.WriteLine("Exporting music from: " + musicExportDir);
 			prog.ClearLog();
-			songEditor.PrepareResources();
 
 			var confirmResult = MessageBox.Show(
 				"About to export all songs in current directory to '" 
@@ -78,8 +77,8 @@ namespace BrawlSongManager.SongExport {
 		}
 
 		private void ExportSongs(DirectoryInfo exportDir, BackgroundWorker bgw) {
+			PrepareResources();
 			object[] stageSongs = SongsByStage.FromCurrentDir;
-
 			HashSet<string> filenamesAdded = new HashSet<string>();
 			string currentDir = exportDir.FullName;
 			for (int i = 0; i < stageSongs.Length; i++) {
@@ -121,6 +120,21 @@ namespace BrawlSongManager.SongExport {
 			} else {
 				// Create an empty placeholder file.
 				File.Create(dest).Dispose();
+			}
+		}
+
+		private void PrepareResources() {
+			// Only need mu_menumain and gct for export
+			songEditor.PrepareMUM();
+			try {
+				songEditor.PrepareGCT();
+			} catch (Exception gctExc) {
+				var confirmResult = MessageBox.Show("Unable to load GCT codes 'RSBE01.gct'."
+					+ " Custom song volume data will not be exported."
+					+ "\nDo you want to continue?", "Confirm Export", MessageBoxButtons.OKCancel);
+				if (confirmResult != DialogResult.OK) {
+					throw new Exception("User cancelled due to lack of 'RSBE01.gct': " + gctExc.Message, gctExc);
+				}
 			}
 		}
 

--- a/SongManager/SongExport/SongImporter.cs
+++ b/SongManager/SongExport/SongImporter.cs
@@ -1,0 +1,170 @@
+using BrawlLib.SSBB.ResourceNodes;
+using BrawlManagerLib;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+
+namespace BrawlSongManager.SongExport {
+	
+	/// <summary>
+	/// Contains logic for importing music song files from an
+	/// easily editable directory structure.
+	/// </summary>
+	public class SongImporter {
+		private static readonly Regex filenameRegex = new Regex(@"(\w\d\d)\.(\d+)\.(.*)\.brstm");
+
+		public bool ExportStageDirs { get; set; }
+
+		private ProgressDialog prog;
+		private SongEditor songEditor;
+		private List<string> warnings;
+		private Dictionary<string, string> importedSongs;
+
+		public SongImporter() {
+			prog = new ProgressDialog();
+			songEditor = new SongEditor();
+			warnings = new List<string>();
+			importedSongs = new Dictionary<string, string>();
+		}
+
+		public void Import(string musicImportDir) {
+			Log("Importing music from: " + musicImportDir);
+			prog.ClearLog();
+			songEditor.PrepareResources();
+
+			var importDir = new DirectoryInfo(musicImportDir);
+			FileInfo[] brstmFiles = importDir.GetFiles("*.brstm", SearchOption.AllDirectories);
+			if (brstmFiles.Length == 0) {
+				MessageBox.Show("No *.brstm files were found in the selected directory!");
+				return;
+			}
+			var confirmResult = MessageBox.Show("About to import from: " + musicImportDir
+				+ "\nThis will overwrite info.pac, mu_menumain and the GCT codeset. "
+				+ "It is recommended to make a backup before continuing."
+				+ "\nDo you want to continue?", "Confirm Import", MessageBoxButtons.OKCancel);
+			if (confirmResult != DialogResult.OK) {
+				return;
+			}
+
+			prog.ProgressTitle = "Importing songs...";
+			prog.InProgressLabel = "Importing songs...";
+			prog.ProgressCompletionAt = 100;
+
+			var bgw = SetupBackgroundImport(brstmFiles, prog);
+			bgw.RunWorkerAsync();
+
+			prog.ShowDialog();
+		}
+
+		private BackgroundWorker SetupBackgroundImport(FileInfo[] brstmFiles, ProgressDialog prog) {
+			BackgroundWorker bgw = new BackgroundWorker();
+			bgw.DoWork += (object sender, DoWorkEventArgs e) => {
+				ImportSongs(brstmFiles, sender as BackgroundWorker);
+			};
+			bgw.WorkerReportsProgress = true;
+			bgw.ProgressChanged += (object sender, ProgressChangedEventArgs e) => {
+				prog.Progress = e.ProgressPercentage;
+				if (e.UserState != null) {
+					prog.InProgressLabel = (string)e.UserState;
+				}
+			};
+			bgw.RunWorkerCompleted += (object sender, RunWorkerCompletedEventArgs e) => {
+				prog.Progress = 100;
+				Log("");
+				string warnMsg = "";
+				if (warnings.Count > 0) {
+					Log("WARNING: There were " + warnings.Count + " warnings during import:");
+					foreach (string warn in warnings) {
+						Log(warn);
+					}
+					Log("");
+					warnMsg = " (with " + warnings.Count + " warnings)";
+				}
+				if (e.Error != null) {
+					Warn("Error importing songs." + e.Error.Message);
+				} else {
+					Log("Completed import" + warnMsg + "!");
+				}
+			};
+			return bgw;
+		}
+
+		private void ImportSongs(FileInfo[] brstmFiles, BackgroundWorker bgw) {
+			for (int i = 0; i < brstmFiles.Length; i++) {
+				bgw.ReportProgress(i * 100 / brstmFiles.Length);
+				FileInfo file = brstmFiles[i];
+				ImportSong(file);
+			}
+			songEditor.SaveResources();
+		}
+
+		private void ImportSong(FileInfo file) {
+			var match = filenameRegex.Match(file.Name);
+			if (!match.Success) {
+				Warn("Skipped file due to incorrect filename format: " + file.FullName);
+				return;
+			}
+			if (file.Length == 0) {
+				Log("Skipped empty file: " + file.FullName);
+				return;
+			}
+
+			string filename = match.Groups[1].Value;
+			byte fileVolume = byte.Parse(match.Groups[2].Value);
+			string title = match.Groups[3].Value;
+
+			if (importedSongs.ContainsKey(filename)) {
+				string first = importedSongs[filename];
+				Warn("Song file '" + filename + "' has already been imported from '"
+					+ first + "'. Skipping subsequent file: " + file.Name);
+				return;
+			}
+			importedSongs.Add(filename, file.Name);
+
+			if (fileVolume > 127) {
+				Warn("Volume decreased to maximum of 127 for file: " + file.FullName);
+				fileVolume = 127;
+			}
+
+			Song defSong = songEditor.GetDefaultSong(filename);
+			if (defSong == null) {
+				Log("Skipped unknown song: " + file.FullName);
+				return;
+			}
+			byte? volume = fileVolume;
+			if (fileVolume == 0) {
+				Log("Ignoring 0 volume for: " + file.FullName);
+				volume = null;
+			} else if (defSong.DefaultVolume.HasValue 
+				&& defSong.DefaultVolume.Value == fileVolume) {
+				volume = null;
+			}
+			Song song = new Song(title, filename, defSong.ID, volume, defSong.InfoPacIndex);
+			songEditor.WriteSong(song);
+
+			File.Copy(file.FullName, new SongInfo(song.Filename).File.FullName, true);
+		}
+
+		private void Log(string message) {
+			if (prog.InvokeRequired) {
+				prog.BeginInvoke((Action)(() => { prog.AppendLogLine(message); }));
+			} else {
+				prog.AppendLogLine(message);
+			}
+		}
+
+		private void Warn(string message) {
+			warnings.Add(message);
+			if (prog.InvokeRequired) {
+				prog.BeginInvoke((Action)(() => { prog.AppendLogLine("WARNING: " + message); }));
+			} else {
+				prog.AppendLogLine(message);
+			}
+		}
+	}
+}

--- a/SongManager/SongManager.csproj
+++ b/SongManager/SongManager.csproj
@@ -86,6 +86,9 @@
     <Compile Include="ReadOnlySearchableRichTextBox.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="SongExport\SongEditor.cs" />
+    <Compile Include="SongExport\SongExporter.cs" />
+    <Compile Include="SongExport\SongImporter.cs" />
     <Compile Include="SongInfo.cs" />
     <Compile Include="SongsByStage.cs" />
     <EmbeddedResource Include="CustomSongVolumeEditor.resx">


### PR DESCRIPTION
Manually editing all the songs one at a time is tedious; particularly if you need to do it again for some reason (such as a new release of PM). This functionality allows a user to export their current songs to a directory with the *.brstm files named with the volume and title (as well as the original game filename). The user can then replace file contents, or change the title or volume of various songs before they import the songs back (as long as the original game filename is in-tact). This also allows easy sharing of a music 'build' as the exported songs can be archived, shared and then imported.
